### PR TITLE
add shape data to info

### DIFF
--- a/MuJoCo_Gym/mujoco_parent.py
+++ b/MuJoCo_Gym/mujoco_parent.py
@@ -345,7 +345,8 @@ class MuJoCoParent:
                 "id": data_geom.id,
                 "name": data_geom.name,
                 "type": "geom",
-                "color": model_geom.rgba
+                "color": model_geom.rgba,
+                "shape": model_geom.type
             }
         return infos
 


### PR DESCRIPTION
save an object's shape information (model_geom.type) which can be used for training different experimental setups (eg. box vs sphere)